### PR TITLE
Adding fields to batch + consolidating batch

### DIFF
--- a/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
+++ b/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
@@ -464,7 +464,6 @@ namespace Azure.ApplicationModel.Configuration.Tests
             try
             {
                 await service.SetAsync(testSettingNoLabel, CancellationToken.None);
-
                 // Test
                 Response<ConfigurationSetting> response = await service.GetAsync(key: testSettingNoLabel.Key, filter: default, CancellationToken.None);
 
@@ -530,7 +529,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
         }
 
         [Test]
-        public async Task GetBatch()
+        public async Task GetBatchPagination()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
             Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
@@ -557,7 +556,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
 
         [Test]
-        public async Task GetList()
+        public async Task GetBatchWithFields()
         {
             var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
             Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
@@ -567,7 +566,12 @@ namespace Azure.ApplicationModel.Configuration.Tests
             {
                 await service.SetAsync(s_testSetting, CancellationToken.None);
 
-                SettingBatch batch = await service.GetListAsync(CancellationToken.None);
+                SettingBatchFilter filter = new SettingBatchFilter()
+                {
+                    Fields = SettingFields.Key | SettingFields.Label | SettingFields.Value
+                };
+
+                SettingBatch batch = await service.GetBatchAsync(filter, CancellationToken.None);
                 int resultsReturned = batch.Count;
 
                 //At least there should be one key available

--- a/Configuration/Azure.Configuration/ConfigurationClient.cs
+++ b/Configuration/Azure.Configuration/ConfigurationClient.cs
@@ -264,27 +264,6 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public async Task<Response<SettingBatch>> GetListAsync(CancellationToken cancellation = default)
-        {
-            var uri = BuildUriForList();
-
-            using (HttpMessage message = Pipeline.CreateMessage(_options, cancellation)) {
-                message.SetRequestLine(PipelineMethod.Get, uri);
-
-                message.AddHeader("Host", uri.Host);
-                message.AddHeader(MediaTypeKeyValueApplicationHeader);
-                AddAuthenticationHeaders(message, uri, PipelineMethod.Get, content: default, _secret, _credential);
-                await Pipeline.ProcessAsync(message).ConfigureAwait(false);
-
-                Response response = message.Response;
-                if (response.Status == 200) {
-                    var batch = await ConfigurationServiceSerializer.ParseBatchAsync(response, null, cancellation);
-                    return new Response<SettingBatch>(response, batch);
-                }
-                else throw new ResponseFailedException(response);
-            }
-        }
-
         public async Task<Response<SettingBatch>> GetRevisionsAsync(SettingBatchFilter filter, CancellationToken cancellation = default)
         {
             var uri = BuildUriForRevisions(filter);

--- a/Configuration/Azure.Configuration/ConfigurationSettingParser.cs
+++ b/Configuration/Azure.Configuration/ConfigurationSettingParser.cs
@@ -48,20 +48,22 @@ namespace Azure.ApplicationModel.Configuration
         private static ConfigurationSetting ReadSetting(JsonElement root)
         {
             // TODO (pri 2): make the deserializer version resilient
-            // TODO (pri 2): can any of these properties not be present in the payload? 
             var setting = new ConfigurationSetting();
-            setting.Key = root.GetProperty("key").GetString();
-            setting.Value = root.GetProperty("value").GetString();
-            setting.Label = root.GetProperty("label").GetString();
-            setting.ContentType = root.GetProperty("content_type").GetString();
-            setting.Locked = root.GetProperty("locked").GetBoolean();
-            setting.ETag = root.GetProperty("etag").GetString();
-            setting.LastModified = DateTimeOffset.Parse(root.GetProperty("last_modified").GetString());
-            foreach (var element in root.GetProperty("tags").EnumerateObject())
+            if (root.TryGetProperty("key", out var keyValue)) setting.Key = keyValue.GetString();
+            if (root.TryGetProperty("value", out var value)) setting.Value = value.GetString();
+            if (root.TryGetProperty("label", out var labelValue)) setting.Label = labelValue.GetString();
+            if (root.TryGetProperty("content_type", out var contentValue)) setting.ContentType = contentValue.GetString();
+            if (root.TryGetProperty("locked", out var lockedValue)) setting.Locked = lockedValue.GetBoolean();
+            if (root.TryGetProperty("etag", out var eTagValue)) setting.ETag = eTagValue.GetString();
+            if (root.TryGetProperty("last_modified", out var lastModifiedValue)) setting.LastModified = DateTimeOffset.Parse(lastModifiedValue.GetString());
+            if (root.TryGetProperty("tags", out var tagsValue))
             {
-                setting.Tags.Add(element.Name, element.Value.GetString());
+                foreach (var element in tagsValue.EnumerateObject())
+                {
+                    setting.Tags.Add(element.Name, element.Value.GetString());
+                }
             }
-            
+
             return setting;
         }
 


### PR DESCRIPTION
The change was mostly to add the option to select which fields to return when doing a batch or revision operation.
In doing so, I deleted the `GetList` method as the only difference from the `GetBacth` was that there were no filters.

Also, I renamed `GetBatch` => `GetBatchPagination` to reflect what the test is actually testing.