### PR TITLE
Enabling full revision 

### DIFF
--- a/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
+++ b/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
@@ -423,7 +423,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 // Test
                 var filter = new SettingBatchFilter();
                 filter.Key = setting.Key;
-
+                filter.Revision = DateTimeOffset.Now;
                 SettingBatch batch = await service.GetRevisionsAsync(filter, CancellationToken.None);
 
                 int resultsReturned = 0;


### PR DESCRIPTION
Fixes from the service team have been submitted. I've tested the changes both in Dogfood and production environment so now it is safe for us to pass `date-time`