### PR TITLE
Implement RequestId

### DIFF
--- a/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
+++ b/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
@@ -419,10 +419,9 @@ namespace Azure.ApplicationModel.Configuration.Tests
             {
                 await service.SetAsync(setting);
                 await service.SetAsync(testSettingUpdate);
-                await Task.Delay(1000);
-
+                
                 // Test
-                var filter = new SettingBatchFilter();
+                var filter = new BatchRequestOptions();
                 filter.Key = setting.Key;
                 filter.Revision = DateTimeOffset.MaxValue;
                 SettingBatch batch = await service.GetRevisionsAsync(filter, CancellationToken.None);

--- a/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
+++ b/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
@@ -107,8 +107,8 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 // Prepare environment
                 var testSettingDiff = s_testSetting.Clone();
                 testSettingDiff.Label = "test_label_diff";
-                await service.SetAsync(s_testSetting, CancellationToken.None);
-                await service.SetAsync(testSettingDiff, CancellationToken.None);
+                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSettingDiff);
 
                 // Test
                 await service.DeleteAsync(key: testSettingDiff.Key, filter: testSettingDiff.Label, CancellationToken.None);
@@ -127,7 +127,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var service = new ConfigurationClient(connectionString);
 
             // Prepare environment
-            await service.SetAsync(s_testSetting, CancellationToken.None);
+            await service.SetAsync(s_testSetting);
 
             // Test
             await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
@@ -141,7 +141,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var service = new ConfigurationClient(connectionString);
 
             // Prepare environment
-            await service.SetAsync(s_testSetting, CancellationToken.None);
+            await service.SetAsync(s_testSetting);
 
             // Test
             ConfigurationSetting settting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);
@@ -163,7 +163,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                Response<ConfigurationSetting> response = await service.SetAsync(s_testSetting, CancellationToken.None);
+                Response<ConfigurationSetting> response = await service.SetAsync(s_testSetting);
 
                 Assert.True(response.TryGetHeader("ETag", out string etagHeader));
 
@@ -186,7 +186,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                Response<ConfigurationSetting> response = await service.AddAsync(s_testSetting, CancellationToken.None);
+                Response<ConfigurationSetting> response = await service.AddAsync(s_testSetting);
 
                 Assert.True(response.TryGetHeader("ETag", out string etagHeader));
 
@@ -215,8 +215,8 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                await service.SetAsync(s_testSetting, CancellationToken.None);
-                await service.SetAsync(testSettingDiff, CancellationToken.None);
+                await service.SetAsync(s_testSetting);
+                await service.SetAsync(testSettingDiff);
 
                 SettingFilter filter = new SettingFilter()
                 {
@@ -241,7 +241,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
             var service = new ConfigurationClient(connectionString);
 
-            await service.SetAsync(s_testSetting, CancellationToken.None);
+            await service.SetAsync(s_testSetting);
             ConfigurationSetting responseGet = await service.GetAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);
 
             var testSettingDiff = responseGet.Clone();
@@ -271,7 +271,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
             var service = new ConfigurationClient(connectionString);
 
-            await service.SetAsync(s_testSetting, CancellationToken.None);
+            await service.SetAsync(s_testSetting);
             ConfigurationSetting setting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);
 
             try
@@ -307,7 +307,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                await service.SetAsync(s_testSetting, CancellationToken.None);
+                await service.SetAsync(s_testSetting);
 
                 var eTag = "ehHuajgQNq5Qg4ruJVB7hlhX8xs";
                 SettingFilter filter = new SettingFilter()
@@ -336,7 +336,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
             var service = new ConfigurationClient(connectionString);
 
-            await service.SetAsync(s_testSetting, CancellationToken.None);
+            await service.SetAsync(s_testSetting);
             ConfigurationSetting responseGet = await service.GetAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);
 
             SettingFilter filter = new SettingFilter()
@@ -376,7 +376,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
             var service = new ConfigurationClient(connectionString);
 
-            await service.SetAsync(s_testSetting, CancellationToken.None);
+            await service.SetAsync(s_testSetting);
             ConfigurationSetting setting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);
             
             try
@@ -417,8 +417,9 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                await service.SetAsync(setting, CancellationToken.None);
-                await service.SetAsync(testSettingUpdate, CancellationToken.None);
+                await service.SetAsync(setting);
+                await service.SetAsync(testSettingUpdate);
+                await Task.Delay(1000);
 
                 // Test
                 var filter = new SettingBatchFilter();
@@ -463,7 +464,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             
             try
             {
-                await service.SetAsync(testSettingNoLabel, CancellationToken.None);
+                await service.SetAsync(testSettingNoLabel);
                 // Test
                 Response<ConfigurationSetting> response = await service.GetAsync(key: testSettingNoLabel.Key, filter: default, CancellationToken.None);
 
@@ -509,8 +510,8 @@ namespace Azure.ApplicationModel.Configuration.Tests
             
             try
             {
-                await service.SetAsync(testSettingNoLabel, CancellationToken.None);
-                await service.SetAsync(s_testSetting, CancellationToken.None);
+                await service.SetAsync(testSettingNoLabel);
+                await service.SetAsync(s_testSetting);
 
                 // Test
                 Response<ConfigurationSetting> response = await service.GetAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
@@ -564,7 +565,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                await service.SetAsync(s_testSetting, CancellationToken.None);
+                await service.SetAsync(s_testSetting);
 
                 SettingBatchFilter filter = new SettingBatchFilter()
                 {
@@ -595,7 +596,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             
             try
             {
-                await service.SetAsync(testSettingNoLabel, CancellationToken.None);
+                await service.SetAsync(testSettingNoLabel);
 
                 ConfigurationSetting setting = await service.GetAsync(testSettingNoLabel.Key, LabelFilters.Null, CancellationToken.None);
                 
@@ -617,7 +618,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             try
             {
                 // Prepare environment
-                await service.SetAsync(s_testSetting, CancellationToken.None);
+                await service.SetAsync(s_testSetting);
 
                 // Test Lock
                 ConfigurationSetting responseLockSetting = await service.LockAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);

--- a/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
+++ b/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
@@ -89,7 +89,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
             var service = new ConfigurationClient(connectionString);
 
-            var response = await service.DeleteAsync(key: s_testSetting.Key, filter: default, CancellationToken.None);
+            var response = await service.DeleteAsync(key: s_testSetting.Key, options: default, CancellationToken.None);
 
             Assert.AreEqual(204, response.Status);
             response.Dispose();
@@ -111,11 +111,11 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 await service.SetAsync(testSettingDiff);
 
                 // Test
-                await service.DeleteAsync(key: testSettingDiff.Key, filter: testSettingDiff.Label, CancellationToken.None);
+                await service.DeleteAsync(key: testSettingDiff.Key, options: testSettingDiff.Label, CancellationToken.None);
             }
             finally
             {
-                await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
             }
         }
 
@@ -130,7 +130,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             await service.SetAsync(s_testSetting);
 
             // Test
-            await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
+            await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
         }
 
         [Test]
@@ -145,13 +145,13 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             // Test
             ConfigurationSetting settting = await service.GetAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);
-            SettingFilter filter = new SettingFilter()
+            RequestOptions options = new RequestOptions()
             {
                 ETag = new ETagFilter() { IfMatch = new ETag(settting.ETag) },
                 Label = settting.Label
             };
 
-            await service.DeleteAsync(key: s_testSetting.Key, filter: filter, CancellationToken.None);
+            await service.DeleteAsync(key: s_testSetting.Key, options: options, CancellationToken.None);
         }
 
         [Test]
@@ -173,7 +173,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
             }
         }
 
@@ -196,7 +196,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
             }
         }
 
@@ -218,19 +218,19 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 await service.SetAsync(s_testSetting);
                 await service.SetAsync(testSettingDiff);
 
-                SettingFilter filter = new SettingFilter()
+                RequestOptions options = new RequestOptions()
                 {
                     ETag = new ETagFilter() { IfMatch = new ETag("*") }
                 };
 
-                ConfigurationSetting responseSetting = await service.UpdateAsync(testSettingUpdate, filter, CancellationToken.None);
+                ConfigurationSetting responseSetting = await service.UpdateAsync(testSettingUpdate, options, CancellationToken.None);
 
                 AssertEqual(testSettingUpdate, responseSetting);
             }
             finally
             {
-                await service.DeleteAsync(key: testSettingUpdate.Key, filter: testSettingUpdate.Label, CancellationToken.None);
-                await service.DeleteAsync(key: testSettingDiff.Key, filter: testSettingDiff.Label, CancellationToken.None);
+                await service.DeleteAsync(key: testSettingUpdate.Key, options: testSettingUpdate.Label, CancellationToken.None);
+                await service.DeleteAsync(key: testSettingDiff.Key, options: testSettingDiff.Label, CancellationToken.None);
             }
         }
 
@@ -249,18 +249,18 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                SettingFilter filter = new SettingFilter()
+                RequestOptions options = new RequestOptions()
                 {
                     ETag = new ETagFilter() { IfMatch = new ETag(testSettingDiff.ETag) }
                 };
 
-                ConfigurationSetting responseSetting = await service.UpdateAsync(testSettingDiff, filter, CancellationToken.None);
+                ConfigurationSetting responseSetting = await service.UpdateAsync(testSettingDiff, options, CancellationToken.None);
 
                 AssertEqual(testSettingDiff, responseSetting);
             }
             finally
             {
-                await service.DeleteAsync(key: testSettingDiff.Key, filter: testSettingDiff.Label, CancellationToken.None);
+                await service.DeleteAsync(key: testSettingDiff.Key, options: testSettingDiff.Label, CancellationToken.None);
             }
         }
 
@@ -276,14 +276,14 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             try
             {
-                SettingFilter filter = new SettingFilter()
+                RequestOptions options = new RequestOptions()
                 {
                     ETag = new ETagFilter() { IfNoneMatch = new ETag(setting.ETag) }
                 };
 
                 var exception = Assert.ThrowsAsync<ResponseFailedException>(async () =>
                 {
-                    await service.UpdateAsync(setting, filter, CancellationToken.None);
+                    await service.UpdateAsync(setting, options, CancellationToken.None);
                 });
 
                 var response = exception.Response;
@@ -291,7 +291,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key: setting.Key, filter: setting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: setting.Key, options: setting.Label, CancellationToken.None);
             }
         }
 
@@ -310,14 +310,14 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 await service.SetAsync(s_testSetting);
 
                 var eTag = "ehHuajgQNq5Qg4ruJVB7hlhX8xs";
-                SettingFilter filter = new SettingFilter()
+                RequestOptions options = new RequestOptions()
                 {
                     ETag = new ETagFilter() { IfMatch = new ETag(eTag) }
                 };
 
                 var exception = Assert.ThrowsAsync<ResponseFailedException>(async () =>
                 {
-                    await service.UpdateAsync(testSettingDiff, filter, CancellationToken.None);
+                    await service.UpdateAsync(testSettingDiff, options, CancellationToken.None);
                 });
 
                 var response = exception.Response;
@@ -325,7 +325,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
             }
         }
 
@@ -339,7 +339,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             await service.SetAsync(s_testSetting);
             ConfigurationSetting responseGet = await service.GetAsync(s_testSetting.Key, s_testSetting.Label, CancellationToken.None);
 
-            SettingFilter filter = new SettingFilter()
+            RequestOptions options = new RequestOptions()
             {
                 ETag = new ETagFilter() { IfMatch = new ETag("*") }
             };
@@ -353,19 +353,19 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 settingTags.Add("tag3", "test_value3");
                 testSettingDiff.Tags = settingTags;
                 
-                ConfigurationSetting responseSetting = await service.UpdateAsync(testSettingDiff, filter, CancellationToken.None);
+                ConfigurationSetting responseSetting = await service.UpdateAsync(testSettingDiff, options, CancellationToken.None);
                 AssertEqual(testSettingDiff, responseSetting);
 
                 // No tags
                 var testSettingNoTags = responseGet.Clone();
                 testSettingNoTags.Tags = null;
 
-                responseSetting = await service.UpdateAsync(testSettingNoTags, filter, CancellationToken.None);
+                responseSetting = await service.UpdateAsync(testSettingNoTags, options, CancellationToken.None);
                 AssertEqual(testSettingNoTags, responseSetting);
             }
             finally
             {
-                await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
             }
         }
 
@@ -381,7 +381,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             
             try
             {
-                SettingFilter filter = new SettingFilter()
+                RequestOptions options = new RequestOptions()
                 {
                     Label = setting.Label,
                     ETag = new ETagFilter() { IfNoneMatch = new ETag(setting.ETag) }
@@ -389,7 +389,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
                 var exception = Assert.ThrowsAsync<ResponseFailedException>(async () =>
                 {
-                    await service.GetAsync(setting.Key, filter, CancellationToken.None);
+                    await service.GetAsync(setting.Key, options, CancellationToken.None);
                 });
 
                 var response = exception.Response;
@@ -397,7 +397,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key: setting.Key, filter: setting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: setting.Key, options: setting.Label, CancellationToken.None);
             }
         }
 
@@ -446,8 +446,8 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key: setting.Key, filter: setting.Label, CancellationToken.None);
-                await service.DeleteAsync(key: testSettingUpdate.Key, filter: testSettingUpdate.Label, CancellationToken.None);
+                await service.DeleteAsync(key: setting.Key, options: setting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: testSettingUpdate.Key, options: testSettingUpdate.Label, CancellationToken.None);
             }
         }
 
@@ -466,7 +466,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             {
                 await service.SetAsync(testSettingNoLabel);
                 // Test
-                Response<ConfigurationSetting> response = await service.GetAsync(key: testSettingNoLabel.Key, filter: default, CancellationToken.None);
+                Response<ConfigurationSetting> response = await service.GetAsync(key: testSettingNoLabel.Key, options: default, CancellationToken.None);
 
                 Assert.True(response.TryGetHeader("ETag", out string etagHeader));
 
@@ -476,7 +476,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key: testSettingNoLabel.Key, filter: default, CancellationToken.None);
+                await service.DeleteAsync(key: testSettingNoLabel.Key, options: default, CancellationToken.None);
             }
         }
 
@@ -489,7 +489,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             
             var e = Assert.ThrowsAsync<ResponseFailedException>(async () =>
             {
-                await service.GetAsync(key: s_testSetting.Key, filter: default, CancellationToken.None);
+                await service.GetAsync(key: s_testSetting.Key, options: default, CancellationToken.None);
             });
 
             var response = e.Response;
@@ -514,7 +514,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 await service.SetAsync(s_testSetting);
 
                 // Test
-                Response<ConfigurationSetting> response = await service.GetAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
+                Response<ConfigurationSetting> response = await service.GetAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
 
                 Assert.True(response.TryGetHeader("ETag", out string etagHeader));
 
@@ -524,8 +524,8 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
-                await service.DeleteAsync(key: testSettingNoLabel.Key, filter: default, CancellationToken.None);
+                await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: testSettingNoLabel.Key, options: default, CancellationToken.None);
             }
         }
 
@@ -540,16 +540,16 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var key = await SetMultipleKeys(service, expectedEvents);
 
             int resultsReturned = 0;
-            SettingBatchFilter filter = new SettingBatchFilter() { Key = key };
+            BatchRequestOptions options = new BatchRequestOptions() { Key = key };
             while (true)
             {
-                using (Response<SettingBatch> response = await service.GetBatchAsync(filter, CancellationToken.None))
+                using (Response<SettingBatch> response = await service.GetBatchAsync(options, CancellationToken.None))
                 {
                     SettingBatch batch = response.Result;
                     resultsReturned += batch.Count;
-                    filter = batch.NextBatch;
+                    options = batch.NextBatch;
 
-                    if (string.IsNullOrEmpty(filter.BatchLink)) break;
+                    if (string.IsNullOrEmpty(options.BatchLink)) break;
                 }
             }
             Assert.AreEqual(expectedEvents, resultsReturned);
@@ -567,12 +567,12 @@ namespace Azure.ApplicationModel.Configuration.Tests
             {
                 await service.SetAsync(s_testSetting);
 
-                SettingBatchFilter filter = new SettingBatchFilter()
+                BatchRequestOptions options = new BatchRequestOptions()
                 {
                     Fields = SettingFields.Key | SettingFields.Label | SettingFields.Value
                 };
 
-                SettingBatch batch = await service.GetBatchAsync(filter, CancellationToken.None);
+                SettingBatch batch = await service.GetBatchAsync(options, CancellationToken.None);
                 int resultsReturned = batch.Count;
 
                 //At least there should be one key available
@@ -580,7 +580,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
             }
         }
 
@@ -646,10 +646,35 @@ namespace Azure.ApplicationModel.Configuration.Tests
             }
             finally
             {
-                await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label, CancellationToken.None);
+                await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
             }
         }
 
+        [Test]
+        public async Task GetWithRequestId()
+        {
+            var connectionString = Environment.GetEnvironmentVariable("AZ_CONFIG_CONNECTION");
+            Assert.NotNull(connectionString, "Set AZ_CONFIG_CONNECTION environment variable to the connection string");
+            var service = new ConfigurationClient(connectionString);
+
+            try
+            {
+                var options = new RequestOptions() { RequestId = Guid.NewGuid() };
+                Response<ConfigurationSetting> response = await service.SetAsync(s_testSetting, options, CancellationToken.None);
+
+                Assert.True(response.TryGetHeader("ETag", out string etagHeader));
+                response.TryGetHeader("x-ms-client-request-id", out string requestId);
+
+                ConfigurationSetting setting = response.Result;
+                AssertEqual(s_testSetting, setting);
+                Assert.AreEqual(requestId, options.RequestId.ToString());
+                response.Dispose();
+            }
+            finally
+            {
+                await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label, CancellationToken.None);
+            }
+        }
     }
 
     public static class ConfigurationSettingExtensions

--- a/Configuration/Azure.Configuration.Test/ConfigurationMockTests.cs
+++ b/Configuration/Azure.Configuration.Test/ConfigurationMockTests.cs
@@ -60,7 +60,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var transport = new GetMockTransport(s_testSetting.Key, default, s_testSetting);
             var (service, pool) = CreateTestService(transport);
 
-            ConfigurationSetting setting = await service.GetAsync(key: s_testSetting.Key, filter : default, CancellationToken.None);
+            ConfigurationSetting setting = await service.GetAsync(key: s_testSetting.Key, options : default, CancellationToken.None);
 
             AssertEqual(s_testSetting, setting);
             Assert.AreEqual(0, pool.CurrentlyRented);
@@ -74,7 +74,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             var e = Assert.ThrowsAsync<ResponseFailedException>(async () =>
             {
-                await service.GetAsync(key: s_testSetting.Key, filter: default, CancellationToken.None);
+                await service.GetAsync(key: s_testSetting.Key, options: default, CancellationToken.None);
             });
             var response = e.Response;
             Assert.AreEqual(404, response.Status);
@@ -113,12 +113,12 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var transport = new UpdateMockTransport(s_testSetting);
             var (service, pool) = CreateTestService(transport);
 
-            SettingFilter filter = new SettingFilter()
+            RequestOptions options = new RequestOptions()
             {
                 ETag = new ETagFilter() { IfMatch = new ETag("*") }
             };
 
-            ConfigurationSetting setting = await service.UpdateAsync(s_testSetting, filter, CancellationToken.None);
+            ConfigurationSetting setting = await service.UpdateAsync(s_testSetting, options, CancellationToken.None);
 
             AssertEqual(s_testSetting, setting);
             Assert.AreEqual(0, pool.CurrentlyRented);
@@ -127,10 +127,10 @@ namespace Azure.ApplicationModel.Configuration.Tests
         [Test]
         public async Task Delete()
         {
-            var transport = new DeleteMockTransport(s_testSetting.Key, new SettingFilter() {Label = s_testSetting.Label }, s_testSetting);
+            var transport = new DeleteMockTransport(s_testSetting.Key, new RequestOptions() {Label = s_testSetting.Label }, s_testSetting);
             var (service, pool) = CreateTestService(transport);
 
-            await service.DeleteAsync(key: s_testSetting.Key, filter: s_testSetting.Label);
+            await service.DeleteAsync(key: s_testSetting.Key, options: s_testSetting.Label);
             Assert.AreEqual(0, pool.CurrentlyRented);
         }
 
@@ -142,7 +142,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             var e = Assert.ThrowsAsync<ResponseFailedException>(async () =>
             {
-                await service.DeleteAsync(key: s_testSetting.Key, filter: default, CancellationToken.None);
+                await service.DeleteAsync(key: s_testSetting.Key, options: default, CancellationToken.None);
             });
             var response = e.Response;
             Assert.AreEqual(404, response.Status);
@@ -182,7 +182,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             var (service, pool) = CreateTestService(transport);
 
-            var query = new SettingBatchFilter();
+            var query = new BatchRequestOptions();
             int keyIndex = 0;
             while (true)
             {
@@ -217,7 +217,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
 
             var e = Assert.ThrowsAsync<ResponseFailedException>(async () =>
             {
-                await client.GetAsync(key: s_testSetting.Key, filter: null, CancellationToken.None);
+                await client.GetAsync(key: s_testSetting.Key, options: null, CancellationToken.None);
             });
             var response = e.Response;
             response.Dispose();

--- a/Configuration/Azure.Configuration.Test/ConfigurationMockTests.cs
+++ b/Configuration/Azure.Configuration.Test/ConfigurationMockTests.cs
@@ -89,7 +89,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var transport = new AddMockTransport(s_testSetting);
             var (service, pool) = CreateTestService(transport);
 
-            ConfigurationSetting setting = await service.AddAsync(setting: s_testSetting, CancellationToken.None);
+            ConfigurationSetting setting = await service.AddAsync(setting: s_testSetting);
 
             AssertEqual(s_testSetting, setting);
             Assert.AreEqual(0, pool.CurrentlyRented);
@@ -101,7 +101,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
             var transport = new SetMockTransport(s_testSetting);
             var (service, pool) = CreateTestService(transport);
 
-            ConfigurationSetting setting = await service.SetAsync(s_testSetting, CancellationToken.None);
+            ConfigurationSetting setting = await service.SetAsync(s_testSetting);
 
             AssertEqual(s_testSetting, setting);
             Assert.AreEqual(0, pool.CurrentlyRented);

--- a/Configuration/Azure.Configuration.Test/MockHttpClientTransport.cs
+++ b/Configuration/Azure.Configuration.Test/MockHttpClientTransport.cs
@@ -67,7 +67,7 @@ namespace Azure.ApplicationModel.Configuration.Test
 
     class DeleteMockTransport : MockHttpClientTransport
     {
-        public DeleteMockTransport(string key, SettingFilter filter, ConfigurationSetting result)
+        public DeleteMockTransport(string key, RequestOptions filter, ConfigurationSetting result)
         {
             _expectedUri = $"https://contoso.azconfig.io/kv/{key}{GetExtraUriParameters(filter)}";
             _expectedRequestContent = null;
@@ -78,7 +78,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _responseContent = json.Replace("lastmodified", "last_modified");
         }
 
-        public DeleteMockTransport(string key, SettingFilter filter, HttpStatusCode statusCode)
+        public DeleteMockTransport(string key, RequestOptions filter, HttpStatusCode statusCode)
             : this(key, filter, result: null)
         {
             Responses.Clear();
@@ -89,7 +89,7 @@ namespace Azure.ApplicationModel.Configuration.Test
     // TODO (pri 3): this should emit the etag response header
     class GetMockTransport : MockHttpClientTransport
     {
-        public GetMockTransport(string queryKey, SettingFilter filter, ConfigurationSetting result)
+        public GetMockTransport(string queryKey, RequestOptions filter, ConfigurationSetting result)
         {
             _expectedMethod = HttpMethod.Get;
             _expectedUri = $"https://contoso.azconfig.io/kv/{queryKey}{GetExtraUriParameters(filter)}";
@@ -100,7 +100,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             _responseContent = json.Replace("lastmodified", "last_modified");
         }
 
-        public GetMockTransport(string queryKey, SettingFilter filter, params HttpStatusCode[] statusCodes)
+        public GetMockTransport(string queryKey, RequestOptions filter, params HttpStatusCode[] statusCodes)
             : this(queryKey, filter, result: null)
         {
             Responses.Clear();
@@ -227,7 +227,7 @@ namespace Azure.ApplicationModel.Configuration.Test
             response.Content.Headers.TryAddWithoutValidation("Content-Type", "application/vnd.microsoft.appconfig.kv+json; charset=utf-8;");
         }
 
-        protected string GetExtraUriParameters(SettingFilter filter)
+        protected string GetExtraUriParameters(RequestOptions filter)
         {
             if (filter != null && filter.Label != null)
             {

--- a/Configuration/Azure.Configuration/ConfigurationClient.cs
+++ b/Configuration/Azure.Configuration/ConfigurationClient.cs
@@ -49,7 +49,7 @@ namespace Azure.ApplicationModel.Configuration
         [HttpError(typeof(ResponseFailedException), 412, Message = "matching item is already in the store")]
         [HttpError(typeof(ResponseFailedException), 429, Message = "too many requests")]
         [UsageErrors(typeof(ResponseFailedException), 401, 403, 408, 500, 502, 503, 504)]
-        public async Task<Response<ConfigurationSetting>> AddAsync(ConfigurationSetting setting, CancellationToken cancellation = default)
+        public async Task<Response<ConfigurationSetting>> AddAsync(ConfigurationSetting setting, SettingFilter filter = null, CancellationToken cancellation = default)
         {
             if (setting == null) throw new ArgumentNullException(nameof(setting));
             if (string.IsNullOrEmpty(setting.Key)) throw new ArgumentNullException($"{nameof(setting)}.{nameof(setting.Key)}");
@@ -67,6 +67,7 @@ namespace Azure.ApplicationModel.Configuration
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
                 message.AddHeader(HttpHeader.Common.CreateContentLength(content.Length));
+                AddFilterHeaders(filter, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Put, content, _secret, _credential);
 
                 message.SetContent(PipelineContent.Create(content));
@@ -81,7 +82,7 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public async Task<Response<ConfigurationSetting>> SetAsync(ConfigurationSetting setting, CancellationToken cancellation = default)
+        public async Task<Response<ConfigurationSetting>> SetAsync(ConfigurationSetting setting, SettingFilter filter = null, CancellationToken cancellation = default)
         {
             if (setting == null) throw new ArgumentNullException(nameof(setting));
             if (string.IsNullOrEmpty(setting.Key)) throw new ArgumentNullException($"{nameof(setting)}.{nameof(setting.Key)}");
@@ -97,6 +98,7 @@ namespace Azure.ApplicationModel.Configuration
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
                 message.AddHeader(HttpHeader.Common.CreateContentLength(content.Length));
+                AddFilterHeaders(filter, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Put, content, _secret, _credential);
 
                 message.SetContent(PipelineContent.Create(content));
@@ -247,9 +249,10 @@ namespace Azure.ApplicationModel.Configuration
 
                 message.AddHeader("Host", uri.Host);
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
-                if (filter.Revision != null) {
+                AddFilterHeaders(filter, message);
+                /*if (filter.Revision != null) {
                     message.AddHeader(AcceptDatetimeHeader, filter.Revision.Value.UtcDateTime.ToString(AcceptDateTimeFormat));
-                }
+                }*/
 
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Get, content: default, _secret, _credential);
 
@@ -273,10 +276,7 @@ namespace Azure.ApplicationModel.Configuration
 
                 message.AddHeader("Host", uri.Host);
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
-                if (filter.Revision != null) {
-                    message.AddHeader(AcceptDatetimeHeader, filter.Revision.Value.UtcDateTime.ToString(AcceptDateTimeFormat));
-                }
-
+                AddFilterHeaders(filter, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Get, content: default, _secret, _credential);
 
                 await Pipeline.ProcessAsync(message).ConfigureAwait(false);

--- a/Configuration/Azure.Configuration/ConfigurationClient.cs
+++ b/Configuration/Azure.Configuration/ConfigurationClient.cs
@@ -49,7 +49,7 @@ namespace Azure.ApplicationModel.Configuration
         [HttpError(typeof(ResponseFailedException), 412, Message = "matching item is already in the store")]
         [HttpError(typeof(ResponseFailedException), 429, Message = "too many requests")]
         [UsageErrors(typeof(ResponseFailedException), 401, 403, 408, 500, 502, 503, 504)]
-        public async Task<Response<ConfigurationSetting>> AddAsync(ConfigurationSetting setting, SettingFilter filter = null, CancellationToken cancellation = default)
+        public async Task<Response<ConfigurationSetting>> AddAsync(ConfigurationSetting setting, RequestOptions options = null, CancellationToken cancellation = default)
         {
             if (setting == null) throw new ArgumentNullException(nameof(setting));
             if (string.IsNullOrEmpty(setting.Key)) throw new ArgumentNullException($"{nameof(setting)}.{nameof(setting.Key)}");
@@ -67,7 +67,7 @@ namespace Azure.ApplicationModel.Configuration
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
                 message.AddHeader(HttpHeader.Common.CreateContentLength(content.Length));
-                AddFilterHeaders(filter, message);
+                AddOptionsHeaders(options, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Put, content, _secret, _credential);
 
                 message.SetContent(PipelineContent.Create(content));
@@ -82,7 +82,7 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public async Task<Response<ConfigurationSetting>> SetAsync(ConfigurationSetting setting, SettingFilter filter = null, CancellationToken cancellation = default)
+        public async Task<Response<ConfigurationSetting>> SetAsync(ConfigurationSetting setting, RequestOptions options = null, CancellationToken cancellation = default)
         {
             if (setting == null) throw new ArgumentNullException(nameof(setting));
             if (string.IsNullOrEmpty(setting.Key)) throw new ArgumentNullException($"{nameof(setting)}.{nameof(setting.Key)}");
@@ -98,7 +98,7 @@ namespace Azure.ApplicationModel.Configuration
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
                 message.AddHeader(HttpHeader.Common.CreateContentLength(content.Length));
-                AddFilterHeaders(filter, message);
+                AddOptionsHeaders(options, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Put, content, _secret, _credential);
 
                 message.SetContent(PipelineContent.Create(content));
@@ -114,7 +114,7 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public async Task<Response<ConfigurationSetting>> UpdateAsync(ConfigurationSetting setting, SettingFilter filter = null, CancellationToken cancellation = default)
+        public async Task<Response<ConfigurationSetting>> UpdateAsync(ConfigurationSetting setting, RequestOptions options = null, CancellationToken cancellation = default)
         {
             if (setting == null) throw new ArgumentNullException(nameof(setting));
             if (string.IsNullOrEmpty(setting.Key)) throw new ArgumentNullException($"{nameof(setting)}.{nameof(setting.Key)}");
@@ -130,7 +130,7 @@ namespace Azure.ApplicationModel.Configuration
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
                 message.AddHeader(HttpHeader.Common.CreateContentLength(content.Length));
-                AddFilterHeaders(filter, message);
+                AddOptionsHeaders(options, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Put, content, _secret, _credential);
 
                 message.SetContent(PipelineContent.Create(content));
@@ -145,17 +145,17 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public async Task<Response> DeleteAsync(string key, SettingFilter filter = null, CancellationToken cancellation = default)
+        public async Task<Response> DeleteAsync(string key, RequestOptions options = null, CancellationToken cancellation = default)
         {
             if (string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
 
-            Uri uri = BuildUriForKvRoute(key, filter);
+            Uri uri = BuildUriForKvRoute(key, options);
 
             using (HttpMessage message = Pipeline.CreateMessage(_options, cancellation)) {
                 message.SetRequestLine(PipelineMethod.Delete, uri);
 
                 message.AddHeader("Host", uri.Host);
-                AddFilterHeaders(filter, message);
+                AddOptionsHeaders(options, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Delete, content: default, _secret, _credential);
 
                 await Pipeline.ProcessAsync(message).ConfigureAwait(false);
@@ -168,17 +168,17 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public async Task<Response<ConfigurationSetting>> LockAsync(string key, SettingFilter filter = null, CancellationToken cancellation = default)
+        public async Task<Response<ConfigurationSetting>> LockAsync(string key, RequestOptions options = null, CancellationToken cancellation = default)
         {
             if (string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
 
-            Uri uri = BuildUriForLocksRoute(key, filter);
+            Uri uri = BuildUriForLocksRoute(key, options);
 
             using (HttpMessage message = Pipeline.CreateMessage(_options, cancellation)) {
                 message.SetRequestLine(PipelineMethod.Put, uri);
 
                 message.AddHeader("Host", uri.Host);
-                AddFilterHeaders(filter, message);
+                AddOptionsHeaders(options, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Put, content: default, _secret, _credential);
 
                 await Pipeline.ProcessAsync(message).ConfigureAwait(false);
@@ -191,17 +191,17 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public async Task<Response<ConfigurationSetting>> UnlockAsync(string key, SettingFilter filter = null, CancellationToken cancellation = default)
+        public async Task<Response<ConfigurationSetting>> UnlockAsync(string key, RequestOptions options = null, CancellationToken cancellation = default)
         {
             if (string.IsNullOrEmpty(key)) throw new ArgumentNullException(nameof(key));
 
-            Uri uri = BuildUriForLocksRoute(key, filter);
+            Uri uri = BuildUriForLocksRoute(key, options);
 
             using (HttpMessage message = Pipeline.CreateMessage(_options, cancellation)) {
                 message.SetRequestLine(PipelineMethod.Delete, uri);
 
                 message.AddHeader("Host", uri.Host);
-                AddFilterHeaders(filter, message);
+                AddOptionsHeaders(options, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Delete, content: default, _secret, _credential);
 
                 await Pipeline.ProcessAsync(message).ConfigureAwait(false);
@@ -214,18 +214,18 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public async Task<Response<ConfigurationSetting>> GetAsync(string key, SettingFilter filter = null, CancellationToken cancellation = default)
+        public async Task<Response<ConfigurationSetting>> GetAsync(string key, RequestOptions options = null, CancellationToken cancellation = default)
         {
             if (string.IsNullOrEmpty(key)) throw new ArgumentNullException($"{nameof(key)}");
 
-            Uri uri = BuildUriForKvRoute(key, filter);
+            Uri uri = BuildUriForKvRoute(key, options);
 
             using (HttpMessage message = Pipeline.CreateMessage(_options, cancellation)) {
                 message.SetRequestLine(PipelineMethod.Get, uri);
 
                 message.AddHeader("Host", uri.Host);
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
-                AddFilterHeaders(filter, message);
+                AddOptionsHeaders(options, message);
                 message.AddHeader(HttpHeader.Common.JsonContentType);
 
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Get, content: default, _secret, _credential);
@@ -240,50 +240,46 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public async Task<Response<SettingBatch>> GetBatchAsync(SettingBatchFilter filter, CancellationToken cancellation = default)
+        public async Task<Response<SettingBatch>> GetBatchAsync(BatchRequestOptions batchOptions, CancellationToken cancellation = default)
         {
-            var uri = BuildUriForGetBatch(filter);
+            var uri = BuildUriForGetBatch(batchOptions);
 
             using (HttpMessage message = Pipeline.CreateMessage(_options, cancellation)) {
                 message.SetRequestLine(PipelineMethod.Get, uri);
 
                 message.AddHeader("Host", uri.Host);
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
-                AddFilterHeaders(filter, message);
-                /*if (filter.Revision != null) {
-                    message.AddHeader(AcceptDatetimeHeader, filter.Revision.Value.UtcDateTime.ToString(AcceptDateTimeFormat));
-                }*/
-
+                AddOptionsHeaders(batchOptions, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Get, content: default, _secret, _credential);
 
                 await Pipeline.ProcessAsync(message).ConfigureAwait(false);
 
                 Response response = message.Response;
                 if (response.Status == 200 || response.Status == 206 /* partial */) {
-                    var batch = await ConfigurationServiceSerializer.ParseBatchAsync(response, filter, cancellation);
+                    var batch = await ConfigurationServiceSerializer.ParseBatchAsync(response, batchOptions, cancellation);
                     return new Response<SettingBatch>(response, batch);
                 }
                 else throw new ResponseFailedException(response);
             }
         }
 
-        public async Task<Response<SettingBatch>> GetRevisionsAsync(SettingBatchFilter filter, CancellationToken cancellation = default)
+        public async Task<Response<SettingBatch>> GetRevisionsAsync(BatchRequestOptions options, CancellationToken cancellation = default)
         {
-            var uri = BuildUriForRevisions(filter);
+            var uri = BuildUriForRevisions(options);
 
             using (HttpMessage message = Pipeline.CreateMessage(_options, cancellation)) {
                 message.SetRequestLine(PipelineMethod.Get, uri);
 
                 message.AddHeader("Host", uri.Host);
                 message.AddHeader(MediaTypeKeyValueApplicationHeader);
-                AddFilterHeaders(filter, message);
+                AddOptionsHeaders(options, message);
                 AddAuthenticationHeaders(message, uri, PipelineMethod.Get, content: default, _secret, _credential);
 
                 await Pipeline.ProcessAsync(message).ConfigureAwait(false);
 
                 Response response = message.Response;
                 if (response.Status == 200 || response.Status == 206 /* partial */) {
-                    var batch = await ConfigurationServiceSerializer.ParseBatchAsync(response, filter, cancellation);
+                    var batch = await ConfigurationServiceSerializer.ParseBatchAsync(response, options, cancellation);
                     return new Response<SettingBatch>(response, batch);
                 }
                 else throw new ResponseFailedException(response);

--- a/Configuration/Azure.Configuration/ConfigurationClient_private.cs
+++ b/Configuration/Azure.Configuration/ConfigurationClient_private.cs
@@ -20,7 +20,7 @@ namespace Azure.ApplicationModel.Configuration
         const string AcceptDateTimeFormat = "ddd, dd MMM yyy HH:mm:ss 'GMT'";
         const string AcceptDatetimeHeader = "Accept-Datetime";
         const string ClientRequestIdHeader = "x-ms-client-request-id";
-        const string ActivateClientRequestId = "x-ms-return-client-request-id";
+        const string EchoClientRequestId = "x-ms-return-client-request-id";
         const string KvRoute = "/kv/";
         const string LocksRoute = "/locks/";
         const string RevisionsRoute = "/revisions/";
@@ -36,34 +36,33 @@ namespace Azure.ApplicationModel.Configuration
         );
 
         // TODO (pri 3): do all the methods that call this accept revisions?
-        static void AddFilterHeaders(SettingFilter filter, HttpMessage message)
+        static void AddOptionsHeaders(RequestOptions options, HttpMessage message)
         {
-            if (filter == null)
+            var requestId = Guid.NewGuid().ToString();
+            if (options != null)
             {
-                message.AddHeader(ClientRequestIdHeader, Guid.NewGuid().ToString());
-                message.AddHeader(ActivateClientRequestId, "true");
-                return;
-            }
+                if (options.ETag.IfMatch != default)
+                {
+                    message.AddHeader(IfMatchName, $"\"{options.ETag.IfMatch}\"");
+                }
 
-            if (filter.ETag.IfMatch != default) {
-                message.AddHeader(IfMatchName, $"\"{filter.ETag.IfMatch}\"");
-            }
+                if (options.ETag.IfNoneMatch != default)
+                {
+                    message.AddHeader(IfNoneMatch, $"\"{options.ETag.IfNoneMatch}\"");
+                }
 
-            if (filter.ETag.IfNoneMatch != default)
-            {
-                message.AddHeader(IfNoneMatch, $"\"{filter.ETag.IfNoneMatch}\"");
+                if (options.Revision.HasValue)
+                {
+                    var dateTime = options.Revision.Value.UtcDateTime.ToString(AcceptDateTimeFormat);
+                    message.AddHeader(AcceptDatetimeHeader, dateTime);
+                }
+                if (options.RequestId != default)
+                {
+                    requestId = options.RequestId.ToString();
+                }
             }
-
-            if (filter.Revision.HasValue) {
-                var dateTime = filter.Revision.Value.UtcDateTime.ToString(AcceptDateTimeFormat);
-                message.AddHeader(AcceptDatetimeHeader, dateTime);
-            }
-            if (filter.RequestId == default)
-            {
-                filter.RequestId = Guid.NewGuid();
-            }
-            message.AddHeader(ClientRequestIdHeader, filter.RequestId.ToString());
-            message.AddHeader(ActivateClientRequestId, "true");
+            message.AddHeader(ClientRequestIdHeader, requestId);
+            message.AddHeader(EchoClientRequestId, "true");
         }
 
         static async Task<Response<ConfigurationSetting>> CreateResponse(Response response, CancellationToken cancellation)
@@ -114,33 +113,33 @@ namespace Azure.ApplicationModel.Configuration
         }
 
         Uri BuildUriForKvRoute(ConfigurationSetting keyValue)
-            => BuildUriForKvRoute(keyValue.Key, new SettingFilter() { Label = keyValue.Label }); // TODO (pri 2) : does this need to filter ETag?
+            => BuildUriForKvRoute(keyValue.Key, new RequestOptions() { Label = keyValue.Label }); // TODO (pri 2) : does this need to filter ETag?
 
-        Uri BuildUriForKvRoute(string key, SettingFilter filter)
+        Uri BuildUriForKvRoute(string key, RequestOptions options)
         {
             var builder = new UriBuilder(_baseUri);
             builder.Path = KvRoute + key;
 
-            if (filter != null && filter.Label != null) {
-                builder.AppendQuery(LabelQueryFilter, filter.Label);                 
+            if (options != null && options.Label != null) {
+                builder.AppendQuery(LabelQueryFilter, options.Label);                 
             }
 
             return builder.Uri;
         }
 
-        Uri BuildUriForLocksRoute(string key, SettingFilter filter)
+        Uri BuildUriForLocksRoute(string key, RequestOptions options)
         {
             var builder = new UriBuilder(_baseUri);
             builder.Path = LocksRoute + key;
 
-            if (filter != null && filter.Label != null) {
-                builder.AppendQuery(LabelQueryFilter, filter.Label);
+            if (options != null && options.Label != null) {
+                builder.AppendQuery(LabelQueryFilter, options.Label);
             }
 
             return builder.Uri;
         }
 
-        void BuildBatchQuery(UriBuilder builder, SettingBatchFilter options)
+        void BuildBatchQuery(UriBuilder builder, BatchRequestOptions options)
         {
             if (!string.IsNullOrEmpty(options.Key))
             {
@@ -175,7 +174,7 @@ namespace Azure.ApplicationModel.Configuration
             return builder.Uri;
         }
 
-        Uri BuildUriForGetBatch(SettingBatchFilter options)
+        Uri BuildUriForGetBatch(BatchRequestOptions options)
         {
             var builder = new UriBuilder(_baseUri);
             builder.Path = KvRoute;
@@ -184,7 +183,7 @@ namespace Azure.ApplicationModel.Configuration
             return builder.Uri;
         }
 
-        Uri BuildUriForRevisions(SettingBatchFilter options)
+        Uri BuildUriForRevisions(BatchRequestOptions options)
         {
             var builder = new UriBuilder(_baseUri);
             builder.Path = RevisionsRoute;

--- a/Configuration/Azure.Configuration/ConfigurationClient_private.cs
+++ b/Configuration/Azure.Configuration/ConfigurationClient_private.cs
@@ -20,6 +20,7 @@ namespace Azure.ApplicationModel.Configuration
         const string AcceptDateTimeFormat = "ddd, dd MMM yyy HH:mm:ss 'GMT'";
         const string AcceptDatetimeHeader = "Accept-Datetime";
         const string ClientRequestIdHeader = "x-ms-client-request-id";
+        const string ActivateClientRequestId = "x-ms-return-client-request-id";
         const string KvRoute = "/kv/";
         const string LocksRoute = "/locks/";
         const string RevisionsRoute = "/revisions/";
@@ -40,6 +41,7 @@ namespace Azure.ApplicationModel.Configuration
             if (filter == null)
             {
                 message.AddHeader(ClientRequestIdHeader, Guid.NewGuid().ToString());
+                message.AddHeader(ActivateClientRequestId, "true");
                 return;
             }
 
@@ -61,6 +63,7 @@ namespace Azure.ApplicationModel.Configuration
                 filter.RequestId = Guid.NewGuid();
             }
             message.AddHeader(ClientRequestIdHeader, filter.RequestId.ToString());
+            message.AddHeader(ActivateClientRequestId, "true");
         }
 
         static async Task<Response<ConfigurationSetting>> CreateResponse(Response response, CancellationToken cancellation)

--- a/Configuration/Azure.Configuration/ConfigurationSetting.cs
+++ b/Configuration/Azure.Configuration/ConfigurationSetting.cs
@@ -145,10 +145,10 @@ namespace Azure.ApplicationModel.Configuration
     public class SettingBatch
     {
         readonly ConfigurationSetting[] _settings;
-        readonly SettingBatchFilter _filter;
+        readonly BatchRequestOptions _filter;
         readonly string _link;
 
-        internal SettingBatch(ConfigurationSetting[] settings, string link, SettingBatchFilter filter)
+        internal SettingBatch(ConfigurationSetting[] settings, string link, BatchRequestOptions filter)
         {
             _settings = settings;
             _link = link;
@@ -159,7 +159,7 @@ namespace Azure.ApplicationModel.Configuration
 
         public int Count => _settings.Length;
 
-        public SettingBatchFilter NextBatch
+        public BatchRequestOptions NextBatch
         {
             get
             {

--- a/Configuration/Azure.Configuration/ConfigurationSettingParser.cs
+++ b/Configuration/Azure.Configuration/ConfigurationSettingParser.cs
@@ -76,7 +76,7 @@ namespace Azure.ApplicationModel.Configuration
             }
         }
 
-        public static async Task<SettingBatch> ParseBatchAsync(Response response, SettingBatchFilter filter, CancellationToken cancellation)
+        public static async Task<SettingBatch> ParseBatchAsync(Response response, BatchRequestOptions filter, CancellationToken cancellation)
         {
             TryGetNextAfterValue(ref response, out string token);
 

--- a/Configuration/Azure.Configuration/Options.cs
+++ b/Configuration/Azure.Configuration/Options.cs
@@ -43,6 +43,8 @@ namespace Azure.ApplicationModel.Configuration
         /// </summary>
         public SettingFields Fields { get; set; } = SettingFields.All;
 
+        public Guid RequestId { get; set; }
+
         public static implicit operator SettingFilter(string label) => new SettingFilter() { Label = label };
 
         #region nobody wants to see these

--- a/Configuration/Azure.Configuration/Options.cs
+++ b/Configuration/Azure.Configuration/Options.cs
@@ -24,7 +24,7 @@ namespace Azure.ApplicationModel.Configuration
         All = uint.MaxValue
     }
 
-    public class SettingFilter
+    public class RequestOptions
     {
         /// <summary>
         /// Specific label of the key.
@@ -45,7 +45,7 @@ namespace Azure.ApplicationModel.Configuration
 
         public Guid RequestId { get; set; }
 
-        public static implicit operator SettingFilter(string label) => new SettingFilter() { Label = label };
+        public static implicit operator RequestOptions(string label) => new RequestOptions() { Label = label };
 
         #region nobody wants to see these
         [EditorBrowsable(EditorBrowsableState.Never)]
@@ -60,7 +60,7 @@ namespace Azure.ApplicationModel.Configuration
         #endregion
     }
 
-    public class SettingBatchFilter : SettingFilter
+    public class BatchRequestOptions : RequestOptions
     {
         /// <summary>
         /// Keys that will be used to filter.
@@ -70,9 +70,9 @@ namespace Azure.ApplicationModel.Configuration
 
         public string BatchLink { get; set; }
 
-        internal SettingBatchFilter Clone()
+        internal BatchRequestOptions Clone()
         {
-            return new SettingBatchFilter()
+            return new BatchRequestOptions()
             {
                 Key = Key,
                 BatchLink = BatchLink


### PR DESCRIPTION
This PR includes:
- Renaming `SettingFilters` to `RequestOptions` to reflect the properties it contains.
- Renaming `SettingBatchFilter` to `BatchRequestOptions` to reflect the properties it contains.
- Add `RequestId` for every call to the service. If the user doesn't provide it, the SDK will generate it.
- Add a test where the user creates and passes the `RequestId`.

This PR doesn't include surfacing the `RequestId` to the user in case of success or exception. I created issue #110 to track that work.