### PR TITLE
Improve reliability of ConfigurationLiveTests.Revisions

### DIFF
--- a/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
+++ b/Configuration/Azure.Configuration.Test/ConfigurationLiveTests.cs
@@ -423,7 +423,7 @@ namespace Azure.ApplicationModel.Configuration.Tests
                 // Test
                 var filter = new SettingBatchFilter();
                 filter.Key = setting.Key;
-                filter.Revision = DateTimeOffset.Now;
+                filter.Revision = DateTimeOffset.MaxValue;
                 SettingBatch batch = await service.GetRevisionsAsync(filter, CancellationToken.None);
 
                 int resultsReturned = 0;


### PR DESCRIPTION
- If client clock is behind server clock, it's possible for the client DateTimeOffset.Now to be older than the server time of the revisions.
- Using DateTimeOffset.MaxValue should ensure all server revisions are older.
- Fixes #113
